### PR TITLE
update tenant to apply team name if present

### DIFF
--- a/plan/resource_plan.go
+++ b/plan/resource_plan.go
@@ -178,11 +178,13 @@ func (p planner) updateManifestWithVarsAndLabels(request config.Request) (err er
 
 func (p planner) otelEnv(env map[any]any, app manifestparser.Application, request config.Request) {
 	p.setIfNotOtelPresent(env, "OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
-	if request.Params.Team != "" {
-		p.setIfNotOtelPresent(env, "OTEL_EXPORTER_OTLP_HEADERS", fmt.Sprintf("X-Scope-OrgId=%s", request.Params.Team))
-	} else {
-		p.setIfNotOtelPresent(env, "OTEL_EXPORTER_OTLP_HEADERS", "X-Scope-OrgId=anonymous")
+
+	team := request.Params.Team
+	if team == "" {
+		team = "anonymous"
 	}
+	p.setIfNotOtelPresent(env, "OTEL_EXPORTER_OTLP_HEADERS", fmt.Sprintf("X-Scope-OrgId=%s", team))
+
 	p.setIfNotOtelPresent(env, "OTEL_SERVICE_NAME", app.Name)
 	p.setIfNotOtelPresent(env, "OTEL_EXPORTER_OTLP_ENDPOINT", "http://opentelemetry-sink.tracing.springernature.io:80")
 	p.setIfNotOtelPresent(env, "OTEL_PROPAGATORS", "tracecontext")

--- a/plan/resource_plan_test.go
+++ b/plan/resource_plan_test.go
@@ -151,7 +151,7 @@ func TestCallsOutToCorrectPlanner(t *testing.T) {
     VAR2: bb
     VAR4: cc
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-    OTEL_EXPORTER_OTLP_HEADERS: "X-Scope-OrgId=ee"
+    OTEL_EXPORTER_OTLP_HEADERS: "X-Scope-OrgId=myTeam"
     OTEL_SERVICE_NAME: "myApp"
     OTEL_EXPORTER_OTLP_ENDPOINT: "http://opentelemetry-sink.tracing.springernature.io:80"
     OTEL_PROPAGATORS: "tracecontext"
@@ -197,7 +197,7 @@ func TestCallsOutToCorrectPlanner(t *testing.T) {
     VAR2: bb
     VAR4: cc
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-    OTEL_EXPORTER_OTLP_HEADERS: "X-Scope-OrgId=ee"
+    OTEL_EXPORTER_OTLP_HEADERS: "X-Scope-OrgId=myTeam"
     OTEL_SERVICE_NAME: "myApp"
     OTEL_EXPORTER_OTLP_ENDPOINT: "http://opentelemetry-sink.tracing.springernature.io:80"
     OTEL_PROPAGATORS: "tracecontext"
@@ -246,7 +246,7 @@ func TestCallsOutToCorrectPlanner(t *testing.T) {
     VAR2: bb
     VAR4: cc
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-    OTEL_EXPORTER_OTLP_HEADERS: "X-Scope-OrgId=ee"
+    OTEL_EXPORTER_OTLP_HEADERS: "X-Scope-OrgId=anonymous"
     OTEL_SERVICE_NAME: "myApp"
     OTEL_EXPORTER_OTLP_ENDPOINT: "http://opentelemetry-sink.tracing.springernature.io:80"
     OTEL_PROPAGATORS: "tracecontext"
@@ -283,7 +283,7 @@ func TestCallsOutToCorrectPlanner(t *testing.T) {
     VAR2: bb
     VAR4: cc
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-    OTEL_EXPORTER_OTLP_HEADERS: "X-Scope-OrgId=ee"
+    OTEL_EXPORTER_OTLP_HEADERS: "X-Scope-OrgId=anonymous"
     OTEL_SERVICE_NAME: "myApp"
     OTEL_EXPORTER_OTLP_ENDPOINT: "http://opentelemetry-sink.tracing.springernature.io:80" 
     OTEL_PROPAGATORS: "tracecontext"
@@ -326,7 +326,7 @@ func TestCallsOutToCorrectPlanner(t *testing.T) {
     VAR2: bb
     VAR4: cc
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-    OTEL_EXPORTER_OTLP_HEADERS: "X-Scope-OrgId=ee"
+    OTEL_EXPORTER_OTLP_HEADERS: "X-Scope-OrgId=anonymous"
     OTEL_SERVICE_NAME: "BLAAAAH"
     OTEL_EXPORTER_OTLP_ENDPOINT: "http://opentelemetry-sink.tracing.springernature.io:80"
     OTEL_PROPAGATORS: "tracecontext"
@@ -374,7 +374,7 @@ func TestCallsOutToCorrectPlanner(t *testing.T) {
     VAR2: bb
     VAR4: cc
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-    OTEL_EXPORTER_OTLP_HEADERS: "X-Scope-OrgId=ee"
+    OTEL_EXPORTER_OTLP_HEADERS: "X-Scope-OrgId=myTeam"
     OTEL_SERVICE_NAME: "myApp"
     OTEL_EXPORTER_OTLP_ENDPOINT: "http://opentelemetry-sink.tracing.springernature.io:80"
     OTEL_PROPAGATORS: "tracecontext"


### PR DESCRIPTION
currently, the tenant is being set to ee for telemetry being pushed via otel directly to us with these env vars. unforntunately, this breaks things for traces (the previous tenant was "single-tenant"). fortunately for us, no one has noticed. 
i'm adding the logic to push traces to the team tenant.